### PR TITLE
bug: update docker with absolute path

### DIFF
--- a/apps/portal/Dockerfile
+++ b/apps/portal/Dockerfile
@@ -23,7 +23,7 @@ RUN npm run build:prod
 FROM nginx:latest
 
 # Copy the built Angular app to the default Nginx public folder
-COPY --from=builder /usr/src/app/dist/* /usr/share/nginx/html/
+COPY --from=builder /usr/src/app/dist/assistant-portal/browser/ /usr/share/nginx/html/
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 


### PR DESCRIPTION
## Portal PR Checklist

### Pre-requisites

- [x] I have gone through the Contributing guidelines for [Submitting a Pull Request (PR)](../../CONTRIBUTING.md#submitting-a-pull-request-pr) and ensured that this is not a duplicate PR.
- [x] I have performed preliminary testing to ensure that any existing features are not impacted and any new features are working as expected.

### PR Details

PR details have been updated as per the given format (see below)

- [x] PR title adheres to the format specified in guidelines (e.g., `feat: add admin login page`)
- [x] Description has been added
- [ ] Related changes have been added (optional)
- [ ] Screenshots have been added (optional)
- [ ] Pending actions have been added (optional)
- [ ] Any other additional notes have been added (optional)

### Additional Information

- [ ] Appropriate label(s) have been added (`ready for review` should be added if the PR is ready to be reviewed)
- [ ] Assignee(s) and reviewer(s) have been added (optional)

---

**Description:**

- Using absolute path in Docker file to fix issue with build files not being recognised after copying.

**Related changes:**

NA
**Screenshots:**

NA
**Pending actions:**

NA
**Additional notes:**

NA